### PR TITLE
wrap text within event modal to stop overflow

### DIFF
--- a/dashboard/src/components/EventModal.js
+++ b/dashboard/src/components/EventModal.js
@@ -1,22 +1,25 @@
 import React from 'react';
 import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
+import './EventModal.scss';
 
 const EventModal = (props) => {
     return (
         <Modal isOpen={props.data.visible} toggle={props.toggle} size={'lg'}>
             <ModalHeader toggle={props.toggle}>Event Info</ModalHeader>
             <ModalBody>
-                <b>Credentials Used: </b>
-                <div>{ props.data.credentials }</div>
-                    
-                <b>Command History:</b>
-                { props.data.commands }
-                                    
-                <b>Urls identified: </b>
-                { props.data.urls.length ? props.data.urls.map((url, index) => <div key={index}>{ url }</div>) : <p>None</p>}
+                <div className="modal-body">
+                    <b>Credentials Used: </b>
+                    <div>{ props.data.credentials }</div>
+                        
+                    <b>Command History:</b>
+                    <div>{ props.data.commands }</div>
+                                        
+                    <b>Urls identified: </b>
+                    <div>{ props.data.urls.length ? props.data.urls.map((url, index) => <div key={index}>{ url }</div>) : <p>None</p>}</div>
 
-                <b>File hashes: </b>
-                { props.data.hashes.length ? props.data.hashes.map((hash, index) => <div key={index}>{ hash }</div>) : <p>None</p>}
+                    <b>File hashes: </b>
+                    <div>{ props.data.hashes.length ? props.data.hashes.map((hash, index) => <div key={index}>{ hash }</div>) : <p>None</p>}</div>
+                </div>
             </ModalBody>
             <ModalFooter>
                 <Button color="secondary" onClick={props.toggle}>Close</Button>

--- a/dashboard/src/components/EventModal.scss
+++ b/dashboard/src/components/EventModal.scss
@@ -1,3 +1,3 @@
-p {
-    margin: 0.25em;
+.modal-body {
+    word-wrap: break-word;
 }


### PR DESCRIPTION
This PR will stop text within the modal from overflowing the modal and being rendered outside of it. Text within the modal will now be wrapped on to a newline to fit the size of the modal.