### PR TITLE
fixed event feed header from having the same styling as the events

### DIFF
--- a/dashboard/src/components/Feed.js
+++ b/dashboard/src/components/Feed.js
@@ -12,7 +12,7 @@ const Feed = props => {
         return(
             <div>
                 <h1 className="feed-title">Event Feed</h1>
-                <div className="feed-container">
+                <div className="feed-header">
                     <div>#</div>
                     <div>Timestamp</div>
                     <div>Source IP</div>

--- a/dashboard/src/components/Feed.scss
+++ b/dashboard/src/components/Feed.scss
@@ -1,6 +1,6 @@
 @import '../stylesheets/variables';
 
-.feed-container {
+.feed-container, .feed-header {
     padding-top: 0.5em;
     padding-bottom: 0.5em;
     margin-left: 10em;
@@ -8,22 +8,26 @@
     display: grid;
     grid-template-columns: 0.1fr 0.5fr 0.4fr 0.3fr 0.3fr 0.3fr;
     grid-template-rows: 1fr;
-    cursor: pointer;
 }
+
 .feed-container:hover {
     background-color: rgba($event-hover, 0.5);
+    cursor: pointer;
 }
+
 .feed-title {
     margin-top: 1em;
     font-size: 3em;
     font-weight: 500;
     margin-bottom: 0.75em;
 }
+
 .feed-table {
     margin: auto;
     border-spacing: 0 0.75em;
     border-collapse: separate;
 }
+
 .table-title {
     padding-left: 4em;
     padding-bottom: 0.75em;


### PR DESCRIPTION
Fixed an issue where the header of the event feed table would have the same color and cursor style as the event items when hovered over.